### PR TITLE
feat: Implement persistent Chrome profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ python src/main.py --monitor-layout separate-screens --displays :0.0 :0.1
 
 # Single display mode
 python src/main.py --single-display
+
+# Specify a custom directory for Chrome profiles
+python src/main.py --profile-dir-prefix /path/to/your/profiles/
 ```
 
 **For dual monitors configured as extended desktop** (most common setup):
@@ -89,6 +92,20 @@ mike@pi4b4:~/dev/chromeremotecontrol $ curl http://localhost:5000/status
 mike@pi4b4:~/dev/chromeremotecontrol $ 
 ```
 
+## Persistent Profiles
+
+By default, Chrome profiles are now stored persistently in your user's configuration directory (e.g., `~/.config/chrome_displayN`). This means that settings, cookies, extensions, and browsing history will be retained across application restarts.
+
+You can customize the base directory for these profiles using the `--profile-dir-prefix` command-line argument. For example, to store profiles in `/mnt/chrome_profiles/`, you would run:
+
+```bash
+python src/main.py --profile-dir-prefix /mnt/chrome_profiles/
+```
+
+This is useful for:
+- Keeping different sets of profiles for different purposes.
+- Storing profiles on a specific storage device.
+- Ensuring that user data is not lost when the application is updated or restarted.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This change modifies the application to use persistent directories for Chrome user profiles, addressing the issue where each startup used a blank slate.

Key changes:
- Chrome instances now use profile directories under `~/.config/` by default (e.g., `~/.config/chrome_display1`). This allows settings, cookies, and extensions to be retained across restarts.
- A new command-line argument `--profile-dir-prefix` has been added to allow you to specify a custom base directory for these profiles.
- The `README.md` has been updated to reflect these changes.

This corresponds to the "use a specific profile for each window" solution, providing a more stable and configurable user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Chrome profiles are now stored persistently by default, preserving settings, cookies, extensions, and browsing history across restarts.
	- Users can specify a custom directory for Chrome profiles using a new command-line argument.

- **Documentation**
	- Updated README with details on persistent profiles and usage examples for custom profile directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->