### PR TITLE
feat: Add display suspend and resume functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Flask-based application for controlling Chrome/Chromium browsers on multiple d
 - Control multiple Chrome instances on different displays
 - Remote control via REST API
 - Navigate, refresh, and monitor browser instances
+- Suspend (turn off) and resume (turn on) displays while preserving layout
 - Robust error handling and cleanup
 
 ## Requirements
@@ -63,6 +64,20 @@ python src/main.py --single-display
 - `GET /display/<id>/current` - Get current URL
 - `GET /status` - Get status of all displays
 - `POST /stop` - Stop all displays
+- `POST /suspend` - Saves current display layout and turns off all displays
+- `POST /resume` - Restores saved display layout and turns on displays
+
+### Suspend Displays
+
+*   **Endpoint:** `/suspend`
+*   **Method:** `POST`
+*   **Description:** Saves the current display layout (resolution, position of connected monitors) and then turns off all active displays using `xrandr`. This is useful for temporarily blanking the screens.
+
+### Resume Displays
+
+*   **Endpoint:** `/resume`
+*   **Method:** `POST`
+*   **Description:** Restores the display layout that was saved prior to the last call to `/suspend`. It turns on the displays and sets them to their previously recorded resolution and position using `xrandr`.
 
 ### Example Usage
 


### PR DESCRIPTION
This commit introduces the ability to suspend and resume displays via API endpoints.

Features:
- Saves the current xrandr display configuration (active outputs, resolution, position) before suspension.
- Turns off all connected displays using `xrandr --output <output> --off`.
- Restores displays to their saved configuration using `xrandr`.
- New API endpoints:
    - `POST /suspend`: Saves state and turns off displays.
    - `POST /resume`: Restores displays to saved state.
- Display state is automatically resumed during graceful application shutdown (via cleanup routine and signal handling).
- Comprehensive logging and error handling for xrandr commands and API calls.
- Updated README with details of the new API endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to suspend and resume displays while preserving their layout.
	- Introduced new REST API endpoints: POST /suspend and POST /resume for managing display power states.
- **Documentation**
	- Updated the README to include details about the new suspend and resume display functionality and API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->